### PR TITLE
Add a stub implementation for the Elfie collector

### DIFF
--- a/Elfie.Indexer.sln
+++ b/Elfie.Indexer.sln
@@ -1,0 +1,63 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Indexing", "src\NuGet.Indexing\NuGet.Indexing.csproj", "{DDB34145-870F-42C3-9663-A9390CEE1E35}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Metadata.Catalog", "src\Catalog\NuGet.Services.Metadata.Catalog.csproj", "{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ng", "src\Ng\Ng.csproj", "{5234D86F-2C0E-4181-AAB7-BBDA3253B4E1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0641F796-3057-494F-BD87-E3932C942890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NgTests", "NgTests\NgTests.csproj", "{05C1C78A-9966-4922-9065-A099023E7366}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DDB34145-870F-42C3-9663-A9390CEE1E35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDB34145-870F-42C3-9663-A9390CEE1E35}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDB34145-870F-42C3-9663-A9390CEE1E35}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DDB34145-870F-42C3-9663-A9390CEE1E35}.Debug|x64.Build.0 = Debug|Any CPU
+		{DDB34145-870F-42C3-9663-A9390CEE1E35}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDB34145-870F-42C3-9663-A9390CEE1E35}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDB34145-870F-42C3-9663-A9390CEE1E35}.Release|x64.ActiveCfg = Release|Any CPU
+		{DDB34145-870F-42C3-9663-A9390CEE1E35}.Release|x64.Build.0 = Release|Any CPU
+		{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}.Debug|x64.ActiveCfg = Debug|x64
+		{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}.Debug|x64.Build.0 = Debug|x64
+		{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}.Release|x64.ActiveCfg = Release|x64
+		{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}.Release|x64.Build.0 = Release|x64
+		{5234D86F-2C0E-4181-AAB7-BBDA3253B4E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5234D86F-2C0E-4181-AAB7-BBDA3253B4E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5234D86F-2C0E-4181-AAB7-BBDA3253B4E1}.Debug|x64.ActiveCfg = Debug|x64
+		{5234D86F-2C0E-4181-AAB7-BBDA3253B4E1}.Debug|x64.Build.0 = Debug|x64
+		{5234D86F-2C0E-4181-AAB7-BBDA3253B4E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5234D86F-2C0E-4181-AAB7-BBDA3253B4E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5234D86F-2C0E-4181-AAB7-BBDA3253B4E1}.Release|x64.ActiveCfg = Release|x64
+		{5234D86F-2C0E-4181-AAB7-BBDA3253B4E1}.Release|x64.Build.0 = Release|x64
+		{05C1C78A-9966-4922-9065-A099023E7366}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{05C1C78A-9966-4922-9065-A099023E7366}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05C1C78A-9966-4922-9065-A099023E7366}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{05C1C78A-9966-4922-9065-A099023E7366}.Debug|x64.Build.0 = Debug|Any CPU
+		{05C1C78A-9966-4922-9065-A099023E7366}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{05C1C78A-9966-4922-9065-A099023E7366}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05C1C78A-9966-4922-9065-A099023E7366}.Release|x64.ActiveCfg = Release|Any CPU
+		{05C1C78A-9966-4922-9065-A099023E7366}.Release|x64.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{05C1C78A-9966-4922-9065-A099023E7366} = {0641F796-3057-494F-BD87-E3932C942890}
+	EndGlobalSection
+EndGlobal

--- a/NgTests/CatalogToElfieOptionsTests.cs
+++ b/NgTests/CatalogToElfieOptionsTests.cs
@@ -27,22 +27,22 @@ namespace NgTests
             string[] args = inputArgs.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
             // Act
-            Catalog2ElfieOptions options = new Catalog2ElfieOptions(args);
+            Catalog2ElfieOptions options = Catalog2ElfieOptions.FromArgs(args);
 
             // Assert
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("catalog2elfie")]
-        [InlineData("catalog2elfie -source -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -maxthreads 1 -verbose true")]
-        [InlineData("catalog2elfie -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -maxthreads 1 -verbose true")]
-        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageType file -storagePath C:\\NuGet -maxthreads 1 -verbose true")]
-        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storagePath C:\\NuGet -maxthreads 1 -verbose true")]
-        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storageType file -maxthreads 1 -verbose true")]
-        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -maxthreads 1 -interval -1 -verbose true")]
-        public void Validate_InvalidValues(string inputArgs)
+        [InlineData(null, typeof(ArgumentNullException))]
+        [InlineData("", typeof(ArgumentOutOfRangeException))]
+        [InlineData("catalog2elfie", typeof(AggregateException))]
+        [InlineData("catalog2elfie -source -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -maxthreads 1 -verbose true", typeof(ArgumentOutOfRangeException))]
+        [InlineData("catalog2elfie -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -maxthreads 1 -verbose true", typeof(AggregateException))]
+        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageType file -storagePath C:\\NuGet -maxthreads 1 -verbose true", typeof(AggregateException))]
+        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storagePath C:\\NuGet -maxthreads 1 -verbose true", typeof(AggregateException))]
+        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storageType file -maxthreads 1 -verbose true", typeof(AggregateException))]
+        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -maxthreads 1 -interval -1 -verbose true", typeof(AggregateException))]
+        public void Validate_InvalidValues(string inputArgs, Type expectedException)
         {
             // Arrange
             string[] args = inputArgs?.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
@@ -50,11 +50,11 @@ namespace NgTests
             // Act
             Action action = delegate
             {
-                Catalog2ElfieOptions options = new Catalog2ElfieOptions(args);
+                Catalog2ElfieOptions options = Catalog2ElfieOptions.FromArgs(args);
             };
 
             // Assert
-            Assert.Throws<AggregateException>(action);
+            Assert.Throws(expectedException, action);
         }
     }
 }

--- a/NgTests/CatalogToElfieOptionsTests.cs
+++ b/NgTests/CatalogToElfieOptionsTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Ng;
+using NgTests.Data;
+using NgTests.Infrastructure;
+using NuGet.Services.Metadata.Catalog;
+using Xunit;
+
+namespace NgTests
+{
+    public class CatalogToElfieOptionsTests
+    {
+        [Theory]
+        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -maxthreads 1 -verbose true")]
+        public void Validate_ValidValues(string inputArgs)
+        {
+            // Arrange
+            string[] args = inputArgs.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Act
+            Catalog2ElfieOptions options = new Catalog2ElfieOptions(args);
+
+            // Assert
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("catalog2elfie")]
+        [InlineData("catalog2elfie -source -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -maxthreads 1 -verbose true")]
+        [InlineData("catalog2elfie -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -maxthreads 1 -verbose true")]
+        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageType file -storagePath C:\\NuGet -maxthreads 1 -verbose true")]
+        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storagePath C:\\NuGet -maxthreads 1 -verbose true")]
+        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storageType file -maxthreads 1 -verbose true")]
+        [InlineData("catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -maxthreads 1 -interval -1 -verbose true")]
+        public void Validate_InvalidValues(string inputArgs)
+        {
+            // Arrange
+            string[] args = inputArgs?.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Act
+            Action action = delegate
+            {
+                Catalog2ElfieOptions options = new Catalog2ElfieOptions(args);
+            };
+
+            // Assert
+            Assert.Throws<AggregateException>(action);
+        }
+    }
+}

--- a/NgTests/CommandHelpersTests.cs
+++ b/NgTests/CommandHelpersTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Ng;
+using NgTests.Data;
+using NgTests.Infrastructure;
+using NuGet.Services.Metadata.Catalog;
+using Xunit;
+
+namespace NgTests
+{
+    public class CommandHelpersTests
+    {
+        [Theory]
+        [InlineData("1", 1)]
+        [InlineData("1234", 1234)]
+        public void GetMaxThreads_ValidValues(string inputValue, int expectedValue)
+        {
+            // Arrange
+            Dictionary<string, string> arguments = new Dictionary<string, string>();
+            arguments.Add("-maxthreads", inputValue);
+
+            // Act
+            int maxThreads = CommandHelpers.GetMaxThreads(arguments);
+
+            // Assert
+            Assert.Equal(expectedValue, maxThreads);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("0")]
+        [InlineData("-1")]
+        [InlineData("-1234")]
+        [InlineData("-thenextparameter")]
+        [InlineData("one")]
+        public void GetMaxThreads_InvalidValues(string inputValue)
+        {
+            int expectedValue = Environment.ProcessorCount;
+
+            // Arrange
+            Dictionary<string, string> arguments = new Dictionary<string, string>();
+            arguments.Add("-maxthreads", inputValue);
+
+            // Act
+            int maxThreads = CommandHelpers.GetMaxThreads(arguments);
+
+            // Assert
+            Assert.Equal(expectedValue, maxThreads);
+        }
+    }
+}

--- a/NgTests/NgTests.csproj
+++ b/NgTests/NgTests.csproj
@@ -60,6 +60,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CatalogToElfieOptionsTests.cs" />
+    <Compile Include="CommandHelpersTests.cs" />
     <Compile Include="DnxCatalogCollectorTests.cs" />
     <Compile Include="Feed2CatalogTests.cs" />
     <Compile Include="Infrastructure\MemoryStorage.cs" />

--- a/src/Ng/Catalog2Elfie.cs
+++ b/src/Ng/Catalog2Elfie.cs
@@ -48,8 +48,22 @@ namespace Ng
 
         void PrintUsage()
         {
+            Console.WriteLine("Creates Elfie index (idx) files for NuGet packages.");
             Console.WriteLine();
-            Console.WriteLine("Usage: ng catalog2elfie -source <catalog> -storageBaseAddress <storage-base-address> -storageType file|azure [-storagePath <path>]|[-storageAccountName <azure-acc> -storageKeyValue <azure-key> -storageContainer <azure-container> -storagePath <path>] [-verbose true|false] [-interval <seconds>] [-maxthreads <int>]");
+            Console.WriteLine("Usage: ng.exe catalog2elfie -source <catalog> -storageType file|azure -storageBaseAddress <storage-base-address> [-storagePath <path>]|[-storageAccountName <azure-acc> -storageKeyValue <azure-key> -storageContainer <azure-container> -storagePath <path>] [-verbose true|false] [-interval <seconds>] [-maxthreads <int>]");
+            Console.WriteLine();
+            Console.WriteLine("    -source              The NuGet catalog source URL. e.g. http://api.nuget.org/v3/catalog0/index.json");
+            Console.WriteLine("    -storageType         file|azure Where to store the idx files. Azure will save to blob storage. File will save to the local file system.");
+            Console.WriteLine("    -storageBaseAddress  The URL which corresponds to the storage root. For Azure, this is the blob storage URL. For File, this is the file:// url to the local file system.");
+            Console.WriteLine("    -storagePath         When storageType=file, the local file path to save the idx files to. e.g. C:\\NuGet\\Crawler");
+            Console.WriteLine("                         When storageType=azure, the relative path within the container to save the idx files to. e.g. NuGet/Crawler");
+            Console.WriteLine("    -storageAccountName  The Azure storage account name. This parameter is only used when storageType=azure.");
+            Console.WriteLine("    -storageKeyValue     The Azure storage key. This parameter is only used when storageType=azure.");
+            Console.WriteLine("    -storageContainer    The Azure storage container. This parameter is only used when storageType=azure.");
+            Console.WriteLine("    -verbose             true|false Writes trace statements to the console. The default value is false. This parameter is only used when storageType=azure.");
+            Console.WriteLine("    -interval            The number of seconds to wait between querying for new or updated packages. The default value is 3 seconds.");
+            Console.WriteLine("    -maxthreads          The maximum number of threads to use for processing. The default value is the number of processors.");
+            Console.WriteLine();
             Console.WriteLine("Example: ng.exe catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -verbose true");
         }
 

--- a/src/Ng/Catalog2Elfie.cs
+++ b/src/Ng/Catalog2Elfie.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Services.Metadata.Catalog.Persistence;
+
+namespace Ng
+{
+    public class Catalog2Elfie
+    {
+        async Task Loop(Catalog2ElfieOptions options, CancellationToken cancellationToken)
+        {
+            Func<HttpMessageHandler> handlerFunc = CommandHelpers.GetHttpMessageHandlerFactory(options.Verbose, null, null);
+
+            Storage storage = options.StorageFactory.Create();
+            ReadWriteCursor front = new DurableCursor(storage.ResolveUri("cursor.json"), storage, MemoryCursor.Min.Value);
+            ReadCursor back = MemoryCursor.Max;
+
+            CommitCollector collector = new ElfieFromCatalogCollector(new Uri(options.Source), storage, options.MaxThreads, handlerFunc);
+
+            while (true)
+            {
+                // Keep running as long as there are more packages to process.
+                bool run = false;
+                do
+                {
+                    run = await collector.Run(front, back, cancellationToken);
+                }
+                while (run);
+
+                // When there are no more packages to process, either stop the application or 
+                // wait a few seconds before checking for new packages.
+                if (options.Interval <= 0)
+                {
+                    break;
+                }
+                else
+                {
+                    Thread.Sleep(options.Interval * 1000);
+                }
+            }
+        }
+
+        void PrintUsage()
+        {
+            Console.WriteLine();
+            Console.WriteLine("Usage: ng catalog2elfie -source <catalog> -storageBaseAddress <storage-base-address> -storageType file|azure [-storagePath <path>]|[-storageAccountName <azure-acc> -storageKeyValue <azure-key> -storageContainer <azure-container> -storagePath <path>] [-verbose true|false] [-interval <seconds>] [-maxthreads <int>]");
+            Console.WriteLine("Example: ng.exe catalog2elfie -source http://api.nuget.org/v3/catalog0/index.json -storageBaseAddress file:///C:/NuGet -storageType file -storagePath C:\\NuGet -verbose true");
+        }
+
+        public void Run(string[] args, CancellationToken cancellationToken)
+        {
+            Catalog2ElfieOptions options;
+
+            try
+            {
+                // Parse the command line arguments
+                options = new Catalog2ElfieOptions(args);
+            }
+            catch (Exception e)
+            {
+                // If the command line arguments were invalid, print help.
+                Console.WriteLine(e.Message);
+
+                AggregateException aggregrateException = e as AggregateException;
+                if (aggregrateException != null)
+                {
+                    foreach (Exception innerException in aggregrateException.InnerExceptions)
+                    {
+                        Console.WriteLine(innerException.Message);
+                    }
+                }
+
+                Trace.TraceError(e.ToString());
+
+                PrintUsage();
+                return;
+            }
+
+            if (options.Verbose)
+            {
+                Trace.Listeners.Add(new ConsoleTraceListener());
+            }
+
+            Trace.TraceInformation("Catalog2Elfie Options: " + options.ToText());
+
+            Loop(options, cancellationToken).Wait();
+        }
+    }
+}

--- a/src/Ng/Catalog2Elfie.cs
+++ b/src/Ng/Catalog2Elfie.cs
@@ -60,7 +60,7 @@ namespace Ng
             try
             {
                 // Parse the command line arguments
-                options = new Catalog2ElfieOptions(args);
+                options = Catalog2ElfieOptions.FromArgs(args);
             }
             catch (Exception e)
             {

--- a/src/Ng/Catalog2ElfieOptions.cs
+++ b/src/Ng/Catalog2ElfieOptions.cs
@@ -14,16 +14,13 @@ namespace Ng
 {
     class Catalog2ElfieOptions
     {
-        public Catalog2ElfieOptions(string[] args)
+        public Catalog2ElfieOptions(string source, IStorageFactory storageFactory, int interval, int maxThreads, bool verbose)
         {
-            this.ParseArgs(args);
-            this.Validate();
-        }
-
-        public IDictionary<string, string> Arguments
-        {
-            get;
-            private set;
+            this.Source = source;
+            this.StorageFactory = storageFactory;
+            this.Interval = interval;
+            this.MaxThreads = maxThreads;
+            this.Verbose = verbose;
         }
 
         public bool Verbose
@@ -38,7 +35,7 @@ namespace Ng
             private set;
         }
 
-        public StorageFactory StorageFactory
+        public IStorageFactory StorageFactory
         {
             get;
             private set;
@@ -54,23 +51,6 @@ namespace Ng
         {
             get;
             private set;
-        }
-
-        private void ParseArgs(string[] args)
-        {
-            if (args != null)
-            {
-                this.Arguments = CommandHelpers.GetArguments(args, 1);
-
-                if (this.Arguments != null)
-                {
-                    this.Verbose = CommandHelpers.GetVerbose(this.Arguments);
-                    this.Source = CommandHelpers.GetSource(this.Arguments);
-                    this.StorageFactory = CommandHelpers.CreateStorageFactory(this.Arguments, this.Verbose);
-                    this.Interval = CommandHelpers.GetInterval(this.Arguments);
-                    this.MaxThreads = CommandHelpers.GetMaxThreads(this.Arguments);
-                }
-            }
         }
 
         private void Validate()
@@ -113,6 +93,32 @@ namespace Ng
             text.Append("Verbose: " + this.Verbose + Environment.NewLine);
 
             return text.ToString();
+        }
+
+        public static Catalog2ElfieOptions FromArgs(string[] args)
+        {
+            if (args == null)
+            {
+                throw new ArgumentNullException("args");
+            }
+
+            IDictionary<string, string> arguments = CommandHelpers.GetArguments(args, 1);
+
+            if (arguments == null)
+            {
+                throw new ArgumentOutOfRangeException("args", "Invalid command line arguments.");
+            }
+
+            bool verbose = CommandHelpers.GetVerbose(arguments);
+            string source= CommandHelpers.GetSource(arguments);
+            IStorageFactory storageFactory = CommandHelpers.CreateStorageFactory(arguments, verbose);
+            int interval = CommandHelpers.GetInterval(arguments);
+            int maxThreads = CommandHelpers.GetMaxThreads(arguments);
+
+            Catalog2ElfieOptions options = new Catalog2ElfieOptions(source, storageFactory, interval, maxThreads, verbose);
+            options.Validate();
+
+            return options;
         }
     }
 }

--- a/src/Ng/Catalog2ElfieOptions.cs
+++ b/src/Ng/Catalog2ElfieOptions.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Services.Metadata.Catalog.Persistence;
+using System.Text;
+
+namespace Ng
+{
+    class Catalog2ElfieOptions
+    {
+        public Catalog2ElfieOptions(string[] args)
+        {
+            this.ParseArgs(args);
+            this.Validate();
+        }
+
+        public IDictionary<string, string> Arguments
+        {
+            get;
+            private set;
+        }
+
+        public bool Verbose
+        {
+            get;
+            private set;
+        }
+
+        public string Source
+        {
+            get;
+            private set;
+        }
+
+        public StorageFactory StorageFactory
+        {
+            get;
+            private set;
+        }
+
+        public int Interval
+        {
+            get;
+            private set;
+        }
+
+        public int MaxThreads
+        {
+            get;
+            private set;
+        }
+
+        private void ParseArgs(string[] args)
+        {
+            if (args != null)
+            {
+                this.Arguments = CommandHelpers.GetArguments(args, 1);
+
+                if (this.Arguments != null)
+                {
+                    this.Verbose = CommandHelpers.GetVerbose(this.Arguments);
+                    this.Source = CommandHelpers.GetSource(this.Arguments);
+                    this.StorageFactory = CommandHelpers.CreateStorageFactory(this.Arguments, this.Verbose);
+                    this.Interval = CommandHelpers.GetInterval(this.Arguments);
+                    this.MaxThreads = CommandHelpers.GetMaxThreads(this.Arguments);
+                }
+            }
+        }
+
+        private void Validate()
+        {
+            List<ArgumentException> exceptions = new List<ArgumentException>();
+
+            if (String.IsNullOrWhiteSpace(this.Source))
+            {
+                exceptions.Add(new ArgumentException("Invalid -source parameter value."));
+            }
+
+            if (this.StorageFactory == null)
+            {
+                exceptions.Add(new ArgumentException("Invalid -storage* parameter values."));
+            }
+
+            if (this.Interval < 0)
+            {
+                exceptions.Add(new ArgumentException("Invalid -interval parameter value. Value must be greater than or equal to zero."));
+            }
+
+            if (this.MaxThreads <= 0)
+            {
+                exceptions.Add(new ArgumentException("Invalid -maxthreads parameter value. Value must be greater than zero."));
+            }
+
+            if (exceptions.Count > 0)
+            {
+                throw new AggregateException("Invalid arguments were passed to the application. See the inner exceptions for details.", exceptions.ToArray());
+            }
+        }
+
+        public string ToText()
+        {
+            StringBuilder text = new StringBuilder();
+            text.Append("Source: " + this.Source + Environment.NewLine);
+            text.Append("StorageFactory: " + this.StorageFactory.ToString() + Environment.NewLine);
+            text.Append("Interval: " + this.Interval + Environment.NewLine);
+            text.Append("MaxThreads: " + this.MaxThreads + Environment.NewLine);
+            text.Append("Verbose: " + this.Verbose + Environment.NewLine);
+
+            return text.ToString();
+        }
+    }
+}

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -470,5 +470,25 @@ namespace Ng
             }
             return handlerFunc;
         }
+
+        public static int GetMaxThreads(IDictionary<string, string> arguments)
+        {
+            int maxThreads = default(int);
+            string maxThreadsValue;
+            if (arguments.TryGetValue("-maxthreads", out maxThreadsValue))
+            {
+                if (!Int32.TryParse(maxThreadsValue, out maxThreads))
+                {
+                    Trace.TraceError("Could not convert -maxthreads value to an integer: \"{0}\"", maxThreadsValue);
+                }
+            }
+
+            if (maxThreads <= 0)
+            {
+                maxThreads = Environment.ProcessorCount;
+            }
+
+            return maxThreads;
+        }
     }
 }

--- a/src/Ng/ElfieFromCatalogCollector.cs
+++ b/src/Ng/ElfieFromCatalogCollector.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ICSharpCode.SharpZipLib.Zip;
+using Newtonsoft.Json.Linq;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Services.Metadata.Catalog.Persistence;
+using NuGet.Versioning;
+
+namespace Ng
+{
+    public class ElfieFromCatalogCollector : CommitCollector
+    {
+        Storage _storage;
+        int _maxThreads;
+
+        public ElfieFromCatalogCollector(Uri index, Storage storage, int maxThreads, Func<HttpMessageHandler> handlerFunc = null)
+            : base(index, handlerFunc)
+        {
+            this._storage = storage;
+            this._maxThreads = maxThreads;
+        }
+
+        protected override async Task<bool> OnProcessBatch(CollectorHttpClient client, IEnumerable<JToken> items, JToken context, DateTime commitTimeStamp, CancellationToken cancellationToken)
+        {
+            Trace.TraceInformation("#StartActivity OnProcessBatch");
+
+            IEnumerable<JObject> catalogItems = await FetchCatalogItems(client, items, cancellationToken);
+
+            ProcessCatalogItems(catalogItems);
+
+            Trace.TraceInformation("#StopActivity OnProcessBatch");
+
+            return true;
+        }
+
+        async Task<IEnumerable<JObject>> FetchCatalogItems(CollectorHttpClient client, IEnumerable<JToken> items, CancellationToken cancellationToken)
+        {
+            Trace.TraceInformation("#StartActivity FetchCatalogItems");
+
+            IList<Task<JObject>> tasks = new List<Task<JObject>>();
+
+            foreach (JToken item in items)
+            {
+                Uri catalogItemUri = item["@id"].ToObject<Uri>();
+
+                tasks.Add(client.GetJObjectAsync(catalogItemUri, cancellationToken));
+            }
+
+            await Task.WhenAll(tasks);
+
+            Trace.TraceInformation("#StopActivity FetchCatalogItems");
+
+            return tasks.Select(t => t.Result);
+        }
+
+        void ProcessCatalogItems(IEnumerable<JObject> catalogItems)
+        {
+            Trace.TraceInformation("#StartActivity ProcessCatalogItems");
+
+            ParallelOptions options = new ParallelOptions()
+            {
+                MaxDegreeOfParallelism = this._maxThreads,
+            };
+
+            Parallel.ForEach(catalogItems, options, catalogItem =>
+            {
+                Trace.TraceInformation("Processing CatalogItem {0}", catalogItem["@id"]);
+
+                NormalizeId(catalogItem);
+
+                if (Utils.IsType(GetContext(catalogItem), catalogItem, Schema.DataTypes.PackageDetails))
+                {
+                    ProcessPackageDetails(catalogItem);
+                }
+                else if (Utils.IsType(GetContext(catalogItem), catalogItem, Schema.DataTypes.PackageDelete))
+                {
+                    ProcessPackageDelete(catalogItem);
+                }
+                else
+                {
+                    Trace.TraceWarning("Unrecognized @type ignoring CatalogItem");
+                }
+            });
+
+            Trace.TraceInformation("#StopActivity ProcessCatalogItems");
+        }
+
+        void ProcessPackageDetails(JObject catalogItem)
+        {
+            if (IsListed(catalogItem))
+            {
+                Trace.TraceInformation("Processing listed package " + catalogItem["@id"].Value<string>());
+            }
+        }
+
+        void ProcessPackageDelete(JObject catalogItem)
+        {
+            Trace.TraceInformation("Processing deleted package " + catalogItem["@id"].Value<string>());
+        }
+
+        void NormalizeId(JObject catalogItem)
+        {
+            JToken originalId = catalogItem["originalId"];
+            if (originalId != null)
+            {
+                catalogItem["id"] = originalId.ToString();
+            }
+        }
+
+        JToken GetContext(JObject catalogItem)
+        {
+            return catalogItem["@context"];
+        }
+
+        bool IsListed(JObject catalogItem)
+        {
+            JToken publishedValue;
+            if (catalogItem.TryGetValue("published", out publishedValue))
+            {
+                var publishedDate = int.Parse(publishedValue.ToObject<DateTime>().ToString("yyyyMMdd"));
+                return (publishedDate != 19000101);
+            }
+            else
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -157,7 +157,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Catalog2Dnx.cs" />
+    <Compile Include="Catalog2ElfieOptions.cs" />
+    <Compile Include="Catalog2Elfie.cs" />
     <Compile Include="DnxCatalogCollector.cs" />
+    <Compile Include="ElfieFromCatalogCollector.cs" />
     <Compile Include="ResetLucene.cs" />
     <Compile Include="Catalog2Lucene.cs" />
     <Compile Include="Catalog2Registration.cs" />

--- a/src/Ng/Program.cs
+++ b/src/Ng/Program.cs
@@ -54,6 +54,10 @@ namespace Ng
                         var catalogToDnx = new Catalog2Dnx();
                         catalogToDnx.Run(args, cancellationTokenSource.Token);
                         break;
+                    case "catalog2elfie":
+                        Catalog2Elfie catalog2Elfie = new Catalog2Elfie();
+                        catalog2Elfie.Run(args, cancellationTokenSource.Token);
+                        break;
                     case "frameworkcompatibility":
                         FrameworkCompatibility.Run(args);
                         break;

--- a/src/Ng/Properties/AssemblyInfo.cs
+++ b/src/Ng/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Ng")]
@@ -15,3 +16,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("e70accdd-c85c-4f55-868b-20d2ffb1293b")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("NgTests")]


### PR DESCRIPTION
This is templated code taken from the existing *2CatalogCollector classes. The CatalogCollector classes enumerate through all the packages in the NuGet catalog. This CatalogCollector is just stubbed out. i.e. There's currently no Elfie implementation. It just prints trace statements for each package it encounters.
