### PR TITLE
Add models for the NuGet json files

### DIFF
--- a/NgTests/Models/CatalogItemTests.cs
+++ b/NgTests/Models/CatalogItemTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Ng;
+using NgTests.Data;
+using NgTests.Infrastructure;
+using Catalog = NuGet.Services.Metadata.Catalog;
+using Xunit;
+using Ng.Models;
+
+namespace NgTests.Models
+{
+    public class CatalogItemTests
+    {
+        [Fact]
+        public void Deserialize_ValidJsonFile()
+        {
+            // Arrange
+            string inputJson = @"{
+                                     ""@id"": ""https://api.nuget.org/v3/catalog0/data/2015.02.02.16.48.21/angularjs.1.0.2.json"",
+                                     ""@type"": [
+                                        ""PackageDetails""
+                                     ],
+                                     ""id"": ""angularjs"",
+                                     ""version"": ""1.0.2"",
+                                 }";
+
+            // Act
+            CatalogItem item = CatalogItem.Deserialize(inputJson);
+
+            // Assert
+            Assert.True(item.PackageId == "angularjs");
+            Assert.True(item.PackageVersion == "1.0.2");
+        }
+
+        [Theory]
+        [InlineData(null, typeof(ArgumentNullException))]
+        [InlineData("", typeof(ArgumentOutOfRangeException))]
+        [InlineData("{}", typeof(ArgumentOutOfRangeException))]
+        [InlineData(@"{""@id"": ""https://foo"", ""@type"": [""PackageDetails""], ""packageId"": ""angularjs"", ""packageVersion"": ""1.0.2"",}", typeof(ArgumentOutOfRangeException))]
+        [InlineData(@"{""@id"": ""https://foo"", ""@type"": [""PackageDetails""], ""version"": ""1.0.2"",}", typeof(ArgumentOutOfRangeException))]
+        [InlineData(@"{""@id"": ""https://foo"", ""@type"": [""PackageDetails""], ""id"": ""angularjs"",}", typeof(ArgumentOutOfRangeException))]
+        [InlineData(@"{""@id"": ""https://foo"", ""@type"": [""PackageDetails""], ""packageId"": """", ""packageVersion"": """",}", typeof(ArgumentOutOfRangeException))]
+        public void Deserialize_InvalidJsonFile(string inputJson, Type expectedException)
+        {
+            // Arrange
+
+            // Act
+            Action action = delegate
+            {
+                CatalogItem item = CatalogItem.Deserialize(inputJson);
+            };
+
+            // Assert
+            Assert.Throws(expectedException, action);
+        }
+    }
+}

--- a/NgTests/Models/RegistrationItemTests.cs
+++ b/NgTests/Models/RegistrationItemTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Ng;
+using NgTests.Data;
+using NgTests.Infrastructure;
+using Catalog = NuGet.Services.Metadata.Catalog;
+using Xunit;
+using Ng.Models;
+
+namespace NgTests.Models
+{
+    public class RegistrationItemTests
+    {
+        const string _validRegistrationItemJson = @"{
+                                                      ""@id"": ""https://api.nuget.org/v3/registration1/newtonsoft.json/8.0.2.json"",
+                                                      ""@type"": [
+                                                        ""Package"",
+                                                      ],
+                                                      ""catalogEntry"": ""https://api.nuget.org/v3/catalog0/data/2016.01.09.01.07.08/newtonsoft.json.8.0.2.json"",
+                                                      ""listed"": true,
+                                                      ""packageContent"": ""https://api.nuget.org/packages/newtonsoft.json.8.0.2.nupkg"",
+                                                      ""published"": ""2016-01-09T01:06:39.39Z"",
+                                                      ""registration"": ""https://api.nuget.org/v3/registration1/newtonsoft.json/index.json"",
+                                                   }";
+
+        [Fact]
+        public void Deserialize_ValidJsonFile()
+        {
+            // Arrange
+            string inputJson = RegistrationItemTests._validRegistrationItemJson;
+
+            // Act
+            RegistrationItem item = RegistrationItem.Deserialize(inputJson);
+
+            // Assert
+            Assert.True(item.Registration.Equals(new Uri("https://api.nuget.org/v3/registration1/newtonsoft.json/index.json")));
+            Assert.True(item.PackageContent.Equals(new Uri("https://api.nuget.org/packages/newtonsoft.json.8.0.2.nupkg")));
+            Assert.True(item.Listed);
+        }
+
+        [Theory]
+        [InlineData(null, typeof(ArgumentNullException))]
+        [InlineData("", typeof(ArgumentOutOfRangeException))]
+        [InlineData("{}", typeof(ArgumentOutOfRangeException))]
+        [InlineData(@"{""@id"": ""id1"", ""@type"": [""type1"",], ""catalogEntry"": ""catalogEntry1"", ""listed"": true, ""registration"": ""registration1"",}", typeof(ArgumentOutOfRangeException))]
+        public void Deserialize_InvalidJsonFile(string inputJson, Type expectedException)
+        {
+            // Arrange
+
+            // Act
+            Action action = delegate
+            {
+                RegistrationItem item = RegistrationItem.Deserialize(inputJson);
+            };
+
+            // Assert
+            Assert.Throws(expectedException, action);
+        }
+    }
+}

--- a/NgTests/Models/ServiceItemTests.cs
+++ b/NgTests/Models/ServiceItemTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Ng;
+using NgTests.Data;
+using NgTests.Infrastructure;
+using Catalog = NuGet.Services.Metadata.Catalog;
+using Xunit;
+using Ng.Models;
+
+namespace NgTests.Models
+{
+    public class ServiceItemTests
+    {
+        const string _validServiceIndexJson = @"{
+                                              ""version"": ""3.0.0-beta.1"",
+                                              ""resources"": [
+                                                {
+                                                  ""@id"": ""https://api-v3search-0.nuget.org/query"",
+                                                  ""@type"": ""SearchQueryService"",
+                                                  ""comment"": ""Query endpoint of NuGet Search service (primary)""
+                                                },
+                                                {
+                                                  ""@id"": ""https://api.nuget.org/v3/registration1/"",
+                                                  ""@type"": ""RegistrationsBaseUrl"",
+                                                  ""comment"": ""Base URL of Azure storage where NuGet package registration info is stored""
+                                                },
+                                             ],
+                                          }";
+
+        [Fact]
+        public void Deserialize_ValidJsonFile()
+        {
+            // Arrange
+            string inputJson = ServiceItemTests._validServiceIndexJson;
+
+            // Act
+            ServiceIndex item = ServiceIndex.Deserialize(inputJson);
+
+            // Assert
+            ServiceIndexResource registrationResource = item.Resources.Where(r => r.Type.Equals("RegistrationsBaseUrl")).FirstOrDefault();
+            Assert.NotNull(registrationResource);
+            Assert.True(registrationResource.Id.Equals(new Uri("https://api.nuget.org/v3/registration1/")));
+        }
+
+        [Theory]
+        [InlineData(null, typeof(ArgumentNullException))]
+        [InlineData("", typeof(ArgumentOutOfRangeException))]
+        [InlineData("{}", typeof(ArgumentOutOfRangeException))]
+        [InlineData(@"{""version"": ""0"", ""resources"": [{""@id"": ""id1"", ""@type"": ""SearchQueryService"", ""comment"": ""comment1""},],}", typeof(ArgumentOutOfRangeException))]
+        [InlineData(@"{""version"": ""0"", ""resources"": [{""@id"": ""id1"", ""@type"": ""SearchQueryService"", ""comment"": ""comment1""}, {""@type"": ""RegistrationsBaseUrl"", ""comment"": ""comment2""},],}", typeof(ArgumentOutOfRangeException))]
+        [InlineData(@"{""version"": ""0"", ""resources"": [{""@id"": ""id1"", ""@type"": ""SearchQueryService"", ""comment"": ""comment1""}, {""@id"": ""id2"", ""comment"": ""comment2""},],}", typeof(ArgumentOutOfRangeException))]
+        [InlineData(@"{""version"": ""0"", ""resources"": [{""@id"": ""id1"", ""@type"": ""SearchQueryService"", ""comment"": ""comment1""}, {""@id"": """", ""@type"": ""RegistrationsBaseUrl"", ""comment"": ""comment2""},],}", typeof(ArgumentOutOfRangeException))]
+        public void Deserialize_InvalidJsonFile(string inputJson, Type expectedException)
+        {
+            // Arrange
+
+            // Act
+            Action action = delegate
+            {
+                ServiceIndex item = ServiceIndex.Deserialize(inputJson);
+            };
+
+            // Assert
+            Assert.Throws(expectedException, action);
+        }
+
+        [Theory]
+        [InlineData(_validServiceIndexJson, "SearchQueryService", "https://api-v3search-0.nuget.org/query")]
+        [InlineData(_validServiceIndexJson, "RegistrationsBaseUrl", "https://api.nuget.org/v3/registration1/")]
+        public void TryGetResourceId_ValidInput(string inputJson, string resourceType, string resourceId)
+        {
+            // Arrange
+            ServiceIndex item = ServiceIndex.Deserialize(inputJson);
+
+            // Act
+            Uri resourceUrl;
+            bool success = item.TryGetResourceId(resourceType, out resourceUrl);
+
+            // Assert
+            Assert.True(success);
+            Assert.True(resourceUrl.OriginalString.Equals(resourceId));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("SEARCHQUERYSERVICE")]
+        [InlineData("Search")]
+        public void TryGetResourceId_InvalidInputType(string inputType)
+        {
+            // Arrange
+            ServiceIndex item = ServiceIndex.Deserialize(ServiceItemTests._validServiceIndexJson);
+
+            // Act
+            Uri resourceUrl;
+            bool success = item.TryGetResourceId(inputType, out resourceUrl);
+
+            // Assert
+            Assert.False(success);
+            Assert.True(resourceUrl == null);
+        }
+    }
+}

--- a/NgTests/NgTests.csproj
+++ b/NgTests/NgTests.csproj
@@ -71,6 +71,9 @@
     <Compile Include="Infrastructure\MockServerHttpClientHandler.cs" />
     <Compile Include="Infrastructure\ODataFeedHelper.cs" />
     <Compile Include="Infrastructure\ODataPackage.cs" />
+    <Compile Include="Models\RegistrationItemTests.cs" />
+    <Compile Include="Models\ServiceItemTests.cs" />
+    <Compile Include="Models\CatalogItemTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegistrationCollectorTests.cs" />
     <Compile Include="TestableFeed2Catalog.cs" />

--- a/src/Ng/App.config
+++ b/src/Ng/App.config
@@ -60,14 +60,19 @@
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
- <system.diagnostics>
-   <trace autoflush="true" indentsize="4">
+  <system.diagnostics>
+    <trace autoflush="true" indentsize="4">
       <listeners>
-        <add name="myListener" 
-          type="System.Diagnostics.TextWriterTraceListener" 
+        <add name="myListener"
+          type="System.Diagnostics.TextWriterTraceListener"
           initializeData="TextWriterOutput.log"  traceOutputOptions="DateTime" />
         <remove name="Default" />
       </listeners>
     </trace>
   </system.diagnostics>
+  <system.net>
+    <connectionManagement>
+      <add address="*" maxconnection="1024"/>
+    </connectionManagement>
+  </system.net>
 </configuration>

--- a/src/Ng/Models/CatalogItem.cs
+++ b/src/Ng/Models/CatalogItem.cs
@@ -1,0 +1,290 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using Newtonsoft.Json;
+using Catalog = NuGet.Services.Metadata.Catalog;
+
+namespace Ng.Models
+{
+    /// <summary>
+    /// Model for a NuGet catalog item, https://api.nuget.org/v3/catalog0/data/2015.02.02.16.48.21/angularjs.1.0.2.json.
+    /// </summary>
+    public class CatalogItem
+    {
+        [JsonProperty(PropertyName = "@id")]
+        public Uri Id
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "@type")]
+        public string[] Type
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "authors")]
+        public string Authors
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "catalog:commitId")]
+        public Guid CommitId
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "catalog:commitTimeStamp")]
+        public DateTime CommitTimeStamp
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "copyright")]
+        public string Copyright
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "created")]
+        public DateTime Created
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "description")]
+        public string Description
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "iconUrl")]
+        public string IconUrl
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "id")]
+        public string PackageId
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "isPrerelease")]
+        public bool IsPrerelease
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "language")]
+        public string Language
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "lastEdited")]
+        public DateTime LastEdited
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "packageHash")]
+        public string PackageHash
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "licenseNames")]
+        public string LicenseNames
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "licenseReportUrl")]
+        public Uri LicenseReportUrl
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "licenseUrl")]
+        public Uri LicenseUrl
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "listed")]
+        public bool Listed
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "originalId")]
+        public string OriginalId
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "packageHashAlgorithm")]
+        public string PackageHashAlgorithm
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "packageSize")]
+        public int PackageSize
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "projectUrl")]
+        public Uri ProjectUrl
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "published")]
+        public DateTime? Published
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "releaseNotes")]
+        public string ReleaseNotes
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "requireLicenseAcceptance")]
+        public bool RequireLicenseAcceptance
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "summary")]
+        public string Summary
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "verbatimVersion")]
+        public string VerbatimVersion
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "version")]
+        public string PackageVersion
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "dependencyGroups")]
+        public DependencyGroup[] DependencyGroups
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "tags")]
+        public string[] Tags
+        {
+            get;
+            private set;
+        }
+
+        [JsonIgnore]
+        public bool IsPackageDetails
+        {
+            get
+            {
+                return this.Type.Contains("PackageDetails");
+            }
+        }
+
+        [JsonIgnore]
+        public bool IsPackageDelete
+        {
+            get
+            {
+                return this.Type.Contains("PackageDelete");
+            }
+        }
+
+        public void NormalizeId()
+        {
+            if (!String.IsNullOrWhiteSpace(this.OriginalId))
+            {
+                this.PackageId = this.OriginalId;
+            }
+        }
+
+        /// <summary>
+        /// Gets the registration information for this item.
+        /// The registration contains links to the download URL as-well-as basic publishing information.
+        /// </summary>
+        /// <param name="nugetServiceUrls">The NugetServiceUrl object which contains the NuGet service endpoints.</param>
+        /// <returns></returns>
+        internal RegistrationItem GetRegistrationItem(NugetServiceEndpoints nugetServiceUrls)
+        {
+            using (Catalog.CollectorHttpClient client = new Catalog.CollectorHttpClient())
+            {
+                // Download the registration json file
+                Uri registrationUrl = nugetServiceUrls.ComposeRegistrationUrl(this.PackageId, this.PackageVersion);
+                string registrationItemJson = client.GetStringAsync(registrationUrl).Result;
+                RegistrationItem registrationItem = RegistrationItem.Deserialize(registrationItemJson);
+
+                return registrationItem;
+            }
+        }
+
+        public static CatalogItem Deserialize(Uri packageDetails)
+        {
+            using (WebClient client = new WebClient())
+            {
+                string json = client.DownloadString(packageDetails);
+                return CatalogItem.Deserialize(json);
+            }
+        }
+
+        public static CatalogItem Deserialize(string json)
+        {
+            return JsonConvert.DeserializeObject<CatalogItem>(json);
+        }
+    }
+}
+

--- a/src/Ng/Models/CatalogItem.cs
+++ b/src/Ng/Models/CatalogItem.cs
@@ -272,18 +272,46 @@ namespace Ng.Models
             }
         }
 
-        public static CatalogItem Deserialize(Uri packageDetails)
+        /// <summary>
+        /// Creates a CatalogItem object from the contents of a URL.
+        /// </summary>
+        /// <param name="catalogItemUrl">The URL that returns the catalog item json.</param>
+        /// <returns>A CatalogItem which represents the contents return by the URL.</returns>
+        public static CatalogItem Deserialize(Uri catalogItemUrl)
         {
             using (WebClient client = new WebClient())
             {
-                string json = client.DownloadString(packageDetails);
+                string json = client.DownloadString(catalogItemUrl);
                 return CatalogItem.Deserialize(json);
             }
         }
 
+        /// <summary>
+        /// Creates a CatalogItem object from the contents of a json string.
+        /// </summary>
+        /// <param name="json">The json string that defines the catalog item.</param>
+        /// <returns>A CatalogItem which represents the json string.</returns>
         public static CatalogItem Deserialize(string json)
         {
-            return JsonConvert.DeserializeObject<CatalogItem>(json);
+            CatalogItem item = JsonConvert.DeserializeObject<CatalogItem>(json);
+
+            // Do some basic validation
+            if (item == null)
+            {
+                throw new ArgumentOutOfRangeException("The json string was not a catalog item.");
+            }
+
+            if (String.IsNullOrWhiteSpace(item.PackageId))
+            {
+                throw new ArgumentOutOfRangeException("The json string did not have a value for the required field 'id'.");
+            }
+
+            if (String.IsNullOrWhiteSpace(item.PackageVersion))
+            {
+                throw new ArgumentOutOfRangeException("The json string did not have a value for the required field 'version'.");
+            }
+
+            return item;
         }
     }
 }

--- a/src/Ng/Models/Dependency.cs
+++ b/src/Ng/Models/Dependency.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Ng.Models
+{
+    /// <summary>
+    /// Model for the dependency node for, https://api.nuget.org/v3/catalog0/data/2015.02.02.16.48.21/angularjs.1.0.2.json#dependencygroup.
+    /// </summary>
+    public class Dependency
+    {
+        [JsonProperty(PropertyName = "@id")]
+        public Uri Id
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "@type")]
+        public String Type
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "id")]
+        public string DependencyId
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "range")]
+        public string VersionRange
+        {
+            get;
+            private set;
+        }
+    }
+}
+

--- a/src/Ng/Models/DependencyGroup.cs
+++ b/src/Ng/Models/DependencyGroup.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Ng.Models
+{
+    /// <summary>
+    /// Model for the dependencygroups node for, https://api.nuget.org/v3/catalog0/data/2015.02.02.16.48.21/angularjs.1.0.2.json#dependencygroup.
+    /// </summary>
+    public class DependencyGroup
+    {
+        [JsonProperty(PropertyName = "@id")]
+        public Uri Id
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "@type")]
+        public String Type
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "dependencies")]
+        public Dependency[] Dependencies
+        {
+            get;
+            private set;
+        }
+    }
+}
+

--- a/src/Ng/Models/RegistrationItem.cs
+++ b/src/Ng/Models/RegistrationItem.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using Newtonsoft.Json;
+
+namespace Ng.Models
+{
+    /// <summary>
+    /// Model for a NuGet registration item, https://api.nuget.org/v3/registration1/newtonsoft.json/8.0.2.json.
+    /// </summary>
+    public class RegistrationItem
+    {
+        [JsonProperty(PropertyName = "@id")]
+        public Uri Id
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "@type")]
+        public string[] Type
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "catalogEntry")]
+        public Uri CatalogEntry
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "listed")]
+        public bool Listed
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "packageContent")]
+        public Uri PackageContent
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "published")]
+        public DateTime Published
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "registration")]
+        public Uri Registration
+        {
+            get;
+            private set;
+        }
+
+        public static RegistrationItem Deserialize(Uri registrationItemUrl)
+        {
+            using (WebClient client = new WebClient())
+            {
+                string json = client.DownloadString(registrationItemUrl);
+                return RegistrationItem.Deserialize(json);
+            }
+        }
+
+        public static RegistrationItem Deserialize(string json)
+        {
+            return JsonConvert.DeserializeObject<RegistrationItem>(json);
+        }
+    }
+}
+

--- a/src/Ng/Models/RegistrationItem.cs
+++ b/src/Ng/Models/RegistrationItem.cs
@@ -65,6 +65,11 @@ namespace Ng.Models
             private set;
         }
 
+        /// <summary>
+        /// Creates a RegistrationItem object from the contents of a URL.
+        /// </summary>
+        /// <param name="registrationItemUrl">The URL that returns the registration item json.</param>
+        /// <returns>A RegistrationItem which represents the contents return by the URL.</returns>
         public static RegistrationItem Deserialize(Uri registrationItemUrl)
         {
             using (WebClient client = new WebClient())
@@ -74,9 +79,27 @@ namespace Ng.Models
             }
         }
 
+        /// <summary>
+        /// Creates a RegistrationItem object from the contents of a json string.
+        /// </summary>
+        /// <param name="json">The json string that defines the registration item.</param>
+        /// <returns>A RegistrationItem which represents the json string.</returns>
         public static RegistrationItem Deserialize(string json)
         {
-            return JsonConvert.DeserializeObject<RegistrationItem>(json);
+            RegistrationItem item = JsonConvert.DeserializeObject<RegistrationItem>(json);
+
+            // Do some basic validation
+            if (item == null)
+            {
+                throw new ArgumentOutOfRangeException("The json string was not a registration item.");
+            }
+
+            if (item.PackageContent == null)
+            {
+                throw new ArgumentOutOfRangeException("The json string did not have a value for the field packageContent.");
+            }
+
+            return item;
         }
     }
 }

--- a/src/Ng/Models/ServiceIndex.cs
+++ b/src/Ng/Models/ServiceIndex.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Ng.Models
+{
+    /// <summary>
+    /// Model for the NuGet service index, http://api.nuget.org/v3/index.json.
+    /// </summary>
+    internal class ServiceIndex
+    {
+        [JsonProperty(PropertyName = "version")]
+        public string Version
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "resources")]
+        public ServiceIndexResource[] Resources
+        {
+            get;
+            private set;
+        }
+
+        public bool TryGetResourceId(string type, out Uri id)
+        {
+            id = this.Resources.FirstOrDefault(r => r.Type.Equals(type, StringComparison.OrdinalIgnoreCase))?.Id;
+            return id != null;
+        }
+
+        public static ServiceIndex Deserialize(Uri serviceIndex)
+        {
+            using (WebClient client = new WebClient())
+            {
+                string json = client.DownloadString(serviceIndex);
+                return ServiceIndex.Deserialize(json);
+            }
+        }
+
+        public static ServiceIndex Deserialize(string json)
+        {
+            return JsonConvert.DeserializeObject<ServiceIndex>(json);
+        }
+    }
+}
+

--- a/src/Ng/Models/ServiceIndex.cs
+++ b/src/Ng/Models/ServiceIndex.cs
@@ -29,24 +29,67 @@ namespace Ng.Models
             private set;
         }
 
+        /// <summary>
+        /// Retrieves the resource id (@id) for the given type.
+        /// </summary>
+        /// <param name="type">The resource type to get the id for. e.g. RegistrationsBaseUrl</param>
+        /// <param name="id">The @id for the resource. e.g. https://api.nuget.org/v3/registration1/</param>
+        /// <returns>True if the @id was found. Otherwise false.</returns>
         public bool TryGetResourceId(string type, out Uri id)
         {
-            id = this.Resources.FirstOrDefault(r => r.Type.Equals(type, StringComparison.OrdinalIgnoreCase))?.Id;
+            try
+            {
+                id = this.Resources.FirstOrDefault(r => r.Type != null && r.Type.Equals(type))?.Id;
+            }
+            catch
+            {
+                id = null;
+            }
+
             return id != null;
         }
 
-        public static ServiceIndex Deserialize(Uri serviceIndex)
+        /// <summary>
+        /// Creates a ServiceIndex object from the contents of a URL.
+        /// </summary>
+        /// <param name="serviceIndexUrl">The URL that returns the service index json.</param>
+        /// <returns>A ServiceIndex which represents the contents return by the URL.</returns>
+        public static ServiceIndex Deserialize(Uri serviceIndexUrl)
         {
             using (WebClient client = new WebClient())
             {
-                string json = client.DownloadString(serviceIndex);
+                string json = client.DownloadString(serviceIndexUrl);
                 return ServiceIndex.Deserialize(json);
             }
         }
 
+        /// <summary>
+        /// Creates a ServiceIndex object from the contents of a json string.
+        /// </summary>
+        /// <param name="json">The json string that defines the service index.</param>
+        /// <returns>A ServiceIndex which represents the json string.</returns>
         public static ServiceIndex Deserialize(string json)
         {
-            return JsonConvert.DeserializeObject<ServiceIndex>(json);
+            ServiceIndex item = JsonConvert.DeserializeObject<ServiceIndex>(json);
+
+            // Do some basic validation
+            if (item == null || item.Resources == null)
+            {
+                throw new ArgumentOutOfRangeException("The json string was not a service index.");
+            }
+
+            Uri registrationUri = item.Resources.FirstOrDefault(r => r.Type != null && r.Type.Equals("RegistrationsBaseUrl", StringComparison.OrdinalIgnoreCase))?.Id;
+            if (registrationUri == null)
+            {
+                throw new ArgumentOutOfRangeException("The json string did not have a resource with @type = RegistrationsBaseUrl");
+            }
+
+            if (String.IsNullOrWhiteSpace(registrationUri.OriginalString))
+            {
+                throw new ArgumentOutOfRangeException("The json string did not have an @id value for the resource @type = RegistrationsBaseUrl");
+            }
+
+            return item;
         }
     }
 }

--- a/src/Ng/Models/ServiceIndexResource.cs
+++ b/src/Ng/Models/ServiceIndexResource.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Ng.Models
+{
+    /// <summary>
+    /// Model for the resources nodes of http://api.nuget.org/v3/index.json#resources.
+    /// </summary>
+    internal class ServiceIndexResource
+    {
+        [JsonProperty(PropertyName = "@id")]
+        public Uri Id
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "@type")]
+        public string Type
+        {
+            get;
+            private set;
+        }
+
+        [JsonProperty(PropertyName = "comment")]
+        public string Comment
+        {
+            get;
+            private set;
+        }
+    }
+}
+

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -161,6 +161,13 @@
     <Compile Include="Catalog2Elfie.cs" />
     <Compile Include="DnxCatalogCollector.cs" />
     <Compile Include="ElfieFromCatalogCollector.cs" />
+    <Compile Include="Models\CatalogItem.cs" />
+    <Compile Include="Models\Dependency.cs" />
+    <Compile Include="Models\DependencyGroup.cs" />
+    <Compile Include="Models\RegistrationItem.cs" />
+    <Compile Include="Models\ServiceIndex.cs" />
+    <Compile Include="Models\ServiceIndexResource.cs" />
+    <Compile Include="NugetServiceEndpoints.cs" />
     <Compile Include="ResetLucene.cs" />
     <Compile Include="Catalog2Lucene.cs" />
     <Compile Include="Catalog2Registration.cs" />

--- a/src/Ng/NugetServiceEndpoints.cs
+++ b/src/Ng/NugetServiceEndpoints.cs
@@ -51,7 +51,7 @@ namespace Ng
         public Uri ComposeRegistrationUrl(string packageId, string packageVersion)
         {
             // The registration URL looks similar to https://api.nuget.org/v3/registration1/autofac.mvc2/2.3.2.632.json
-            string relativePath = String.Format("{0}/{1}.json", packageId, packageVersion);
+            string relativePath = $"{packageId}/{packageVersion}.json";
 
             // The URL path must be lower cased.
             relativePath = relativePath.ToLowerInvariant();

--- a/src/Ng/NugetServiceEndpoints.cs
+++ b/src/Ng/NugetServiceEndpoints.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Ng.Models;
+using NuGet.Services.Metadata.Catalog;
+
+namespace Ng
+{
+    /// <summary>
+    /// Container type for all the NuGet service endpoints.
+    /// </summary>
+    class NugetServiceEndpoints
+    {
+        /// <summary>
+        /// Creates a new NugetServiceUrl type using the service endpoints defined in the serviceIndexUrl provided.
+        /// </summary>
+        /// <param name="serviceIndexUrl">The service index endpoint which contains the definition of the NuGet services. e.g. https://api.nuget.org/v3/index.json</param>
+        public NugetServiceEndpoints(Uri serviceIndexUrl)
+        {
+            this.InitializeAsync(serviceIndexUrl).Wait();
+        }
+
+        /// <summary>
+        /// The root service endpoint which contains the defintion for all the other endpoints. e.g. https://api.nuget.org/v3/index.json
+        /// </summary>
+        public Uri ServiceIndexUrl
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The base URL for the registration endpoints. e.g. https://api.nuget.org/v3/registration1/
+        /// </summary>
+        public Uri RegistrationBaseUrl
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Composes the registration URL for the specified package. e.g. https://api.nuget.org/v3/registration1/autofac.mvc2/2.3.2.632.json
+        /// </summary>
+        /// <param name="packageId">The package id.</param>
+        /// <param name="packageVersion">The package version.</param>
+        /// <returns>The registration URL for the specified package.</returns>
+        public Uri ComposeRegistrationUrl(string packageId, string packageVersion)
+        {
+            // The registration URL looks similar to https://api.nuget.org/v3/registration1/autofac.mvc2/2.3.2.632.json
+            string relativePath = String.Format("{0}/{1}.json", packageId, packageVersion);
+
+            // The URL path must be lower cased.
+            relativePath = relativePath.ToLowerInvariant();
+
+            Uri registrationUrl = new Uri(this.RegistrationBaseUrl, relativePath);
+            return registrationUrl;
+        }
+
+        /// <summary>
+        /// Sets the service endpoint property values to the ones defined in the specified service index.
+        /// </summary>
+        /// <param name="serviceIndexUrl">The service index endpoint which contains the endpoints of the NuGet services.</param>
+        private async Task InitializeAsync(Uri serviceIndexUrl)
+        {
+            ServiceIndex serviceIndex;
+
+            using (CollectorHttpClient client = new CollectorHttpClient())
+            {
+                string serviceIndexText = await client.GetStringAsync(serviceIndexUrl);
+                serviceIndex = ServiceIndex.Deserialize(serviceIndexText);
+            }
+
+            Uri registrationBaseUrl;
+            if (!serviceIndex.TryGetResourceId("RegistrationsBaseUrl", out registrationBaseUrl))
+            {
+                throw new ArgumentOutOfRangeException("serviceIndexAddress", "The service index does not contain a RegistrationBaseUrl entry.");
+            }
+
+            this.RegistrationBaseUrl = registrationBaseUrl;
+            this.ServiceIndexUrl = serviceIndexUrl;
+        }
+
+        /// <summary>
+        /// Composes the service index endpoint for the specified catalog index endpoint.
+        /// </summary>
+        /// <param name="catalogIndexUrl">The catalog index service endpoint.</param>
+        /// <returns>The service index endpoint for the specified catalog index endpoint.</returns>
+        public static Uri ComposeServiceIndexUrlFromCatalogIndexUrl(Uri catalogIndexUrl)
+        {
+            // Convert from http://api.nuget.org/v3/catalog0/index.json
+            //           to http://api.nuget.org/v3/index.json
+            // or
+            //         from https://www.myget.org/F/feedname/api/v3/catalog0/index.json
+            //           to https://www.myget.org/F/feedname/api/v3/index.json
+
+            if (catalogIndexUrl.Segments.Length < 4)
+            {
+                throw new ArgumentOutOfRangeException("catalogIndexUrl", "catalogIndexUrl must be a v3 catalog URL of the form http://api.nuget.org/v3/catalog0/index.json");
+            }
+
+            // baseAddress is the schema and domain. e.g. http://api.nuget.org
+            string baseAddress = catalogIndexUrl.GetLeftPart(UriPartial.Authority);
+
+            // relativePath is the path minus the last two segments. e.g. /v3/
+            string relativePath = String.Concat(catalogIndexUrl.Segments.Take(catalogIndexUrl.Segments.Length - 2));
+
+            // Add the index file to the relative path to form the final path segment. e.g. /v3/index.json
+            relativePath += "index.json";
+
+            // serviceIndexUrl is the url of the v3 services index. e.g. http://api.nuget.org/v3/index.json
+            Uri serviceIndexUrl = new Uri(new Uri(baseAddress), relativePath);
+            return serviceIndexUrl;
+        }
+    }
+}
+


### PR DESCRIPTION
The PR was getting too long so I decided to split it up. This first PR adds models for the NuGet json files. 
Interacting with the JObject types was getting too cumbersome. This should make the json files easier to work with and prevents us from having to understand each schema in detail.
