### PR TITLE
Download packages to storage

### DIFF
--- a/NgTests/NgTests.csproj
+++ b/NgTests/NgTests.csproj
@@ -74,6 +74,8 @@
     <Compile Include="Models\RegistrationItemTests.cs" />
     <Compile Include="Models\ServiceItemTests.cs" />
     <Compile Include="Models\CatalogItemTests.cs" />
+    <Compile Include="Persistence\IStorageTests.cs" />
+    <Compile Include="Persistence\StreamStorageContentTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegistrationCollectorTests.cs" />
     <Compile Include="TestableFeed2Catalog.cs" />

--- a/NgTests/Persistence/IStorageTests.cs
+++ b/NgTests/Persistence/IStorageTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Ng;
+using NgTests.Data;
+using NgTests.Infrastructure;
+using NuGet.Services.Metadata.Catalog;
+using Xunit;
+using NuGet.Services.Metadata.Catalog.Persistence;
+
+namespace NgTests.Persistence
+{
+    public class IStorageTests
+    {
+        [Theory]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", "1.2.3.4", "glitter.nupkg", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4/glitter.nupkg")]
+        [InlineData("http://microsoft.com/storage/v1", "My.Shiny.New.Package", "1.2.3.4", "glitter.nupkg", "http://microsoft.com/storage/v1/packages/my.shiny.new.package/1.2.3.4/glitter.nupkg")]
+        [InlineData("http://microsoft.com/storage/Version 1.1/Alpha/", "My.Shiny.New.Package", "1.2.3.4", "glitter.nupkg", "http://microsoft.com/storage/Version 1.1/Alpha/packages/my.shiny.new.package/1.2.3.4/glitter.nupkg")]
+        [InlineData("http://microsoft.com/storage/", "清原容.疑者", "1.2.3.4", "相事務.nupkg", "http://microsoft.com/storage/packages/清原容.疑者/1.2.3.4/相事務.nupkg")]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", "1.2.3-beta1", "glitter.nupkg", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3-beta1/glitter.nupkg")]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", "1.2.3.4.5.6.7.8", "glitter.nupkg", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4.5.6.7.8/glitter.nupkg")]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", "1.2.3.4", "glitter", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4/glitter")]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", "1.2.3.4", "glitter.zip", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4/glitter.zip")]
+        [InlineData("http://microsoft.com/storage/", "a<b>c:d", "1.2.3.4", "glitter.nupkg", "http://microsoft.com/storage/packages/a-b-c-d/1.2.3.4/glitter.nupkg")]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", "a<b>c:d", "glitter.nupkg", "http://microsoft.com/storage/packages/my.shiny.new.package/a-b-c-d/glitter.nupkg")]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", "1.2.3.4", "a<b>c:d.a<b>c:d", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4/a-b-c-d.a-b-c-d")]
+        public void ComposePackageResourceUrl_ValidInputs(string baseAddress, string packageId, string packageVersion, string filename, string expectedAddress)
+        {
+            // Arrange
+            Uri baseUri = new Uri(baseAddress);
+            MemoryStorage storage = new MemoryStorage(baseUri);
+
+            // Act
+            Uri registrationUri = storage.ComposePackageResourceUrl(packageId, packageVersion, filename);
+
+            // Assert
+            Uri expectedUri = new Uri(expectedAddress);
+            Assert.True(registrationUri.Equals(expectedUri));
+        }
+
+        [Theory]
+        [InlineData("http://microsoft.com/storage/", null, "1.2.3.4", "glitter.nupkg", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4/glitter.nupkg", typeof(ArgumentNullException))]
+        [InlineData("http://microsoft.com/storage/", "", "1.2.3.4", "glitter.nupkg", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4/glitter.nupkg", typeof(ArgumentNullException))]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", null, "glitter.nupkg", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4/glitter.nupkg", typeof(ArgumentNullException))]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", "", "glitter.nupkg", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4/glitter.nupkg", typeof(ArgumentNullException))]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", "1.2.3.4", null, "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4/glitter.nupkg", typeof(ArgumentNullException))]
+        [InlineData("http://microsoft.com/storage/", "My.Shiny.New.Package", "1.2.3.4", "", "http://microsoft.com/storage/packages/my.shiny.new.package/1.2.3.4/glitter.nupkg", typeof(ArgumentNullException))]
+        public void ComposePackageResourceUrl_InvalidInputs(string baseAddress, string packageId, string packageVersion, string filename, string expectedAddress, Type expectedException)
+        {
+            // Arrange
+            Uri baseUri = new Uri(baseAddress);
+            MemoryStorage storage = new MemoryStorage(baseUri);
+
+            // Act
+            Action action = delegate
+            {
+                Uri registrationUri = storage.ComposePackageResourceUrl(packageId, packageVersion, filename);
+            };
+
+            // Assert
+            Assert.Throws(expectedException, action);
+        }
+    }
+}

--- a/NgTests/Persistence/StreamStorageContentTests.cs
+++ b/NgTests/Persistence/StreamStorageContentTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Ng;
+using NgTests.Data;
+using NgTests.Infrastructure;
+using NuGet.Services.Metadata.Catalog;
+using Xunit;
+using NuGet.Services.Metadata.Catalog.Persistence;
+
+namespace NgTests.Persistence
+{
+    public class StreamStorageContentTests
+    {
+        [Fact]
+        public void Dispose_MemoryStream()
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 }))
+            {
+                // Arrange
+                StreamStorageContent content = new StreamStorageContent(stream);
+
+                // Act
+                content.Dispose();
+
+                // Assert
+                Assert.Throws<ObjectDisposedException>(delegate { long l = stream.Length; });
+            }
+        }
+
+        [Fact]
+        public void Dispose_MemoryStreamAlreadyDisposed()
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 }))
+            {
+                // Arrange
+                StreamStorageContent content = new StreamStorageContent(stream);
+                stream.Dispose();
+
+                // Act
+                content.Dispose();
+
+                // Assert
+                Assert.Throws<ObjectDisposedException>(delegate { long l = stream.Length; });
+            }
+        }
+
+
+        [Fact]
+        public void Dispose_NullStream()
+        {
+            // Arrange
+            StreamStorageContent content = new StreamStorageContent(null);
+
+            // Act
+            content.Dispose();
+
+            // Assert
+        }
+    }
+}

--- a/src/Catalog/Persistence/StorageContent.cs
+++ b/src/Catalog/Persistence/StorageContent.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
 using System.IO;
 
 namespace NuGet.Services.Metadata.Catalog.Persistence
 {
-    public abstract class StorageContent
+    public abstract class StorageContent : IDisposable
     {
         public string ContentType
         {
@@ -19,5 +20,24 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         }
 
         public abstract Stream GetContentStream();
+
+        #region IDisposable Support  
+        private bool _disposedValue = false;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                }
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+        #endregion
     }
 }

--- a/src/Catalog/Persistence/StreamStorageContent.cs
+++ b/src/Catalog/Persistence/StreamStorageContent.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
 using System.IO;
 
 namespace NuGet.Services.Metadata.Catalog.Persistence
@@ -23,5 +24,29 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         {
             return Content;
         }
+
+        #region IDisposable Support  
+        private bool _disposedValue = false;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!this._disposedValue)
+            {
+                if (disposing)
+                {
+                    // Dispose the content stream.  
+                    if (this.Content != null)
+                    {
+                        this.Content.Dispose();
+                    }
+                }
+
+                this._disposedValue = true;
+
+                base.Dispose(disposing);
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Ng/ElfieFromCatalogCollector.cs
+++ b/src/Ng/ElfieFromCatalogCollector.cs
@@ -180,7 +180,7 @@ namespace Ng
                 string packageFileName = Path.GetFileName(packageDownloadUrl.LocalPath);
 
                 // This is the storage path for the package.  
-                packageResourceUri = this._storage.GetPackageResourceUrl(catalogItem.PackageId, catalogItem.PackageVersion, packageFileName);
+                packageResourceUri = this._storage.ComposePackageResourceUrl(catalogItem.PackageId, catalogItem.PackageVersion, packageFileName);
 
                 // Check if we already downloaded the package in a previous run. 
                 using (StorageContent packageStorageContent = await this._storage.Load(packageResourceUri, cancellationToken))

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Models\ServiceIndex.cs" />
     <Compile Include="Models\ServiceIndexResource.cs" />
     <Compile Include="NugetServiceEndpoints.cs" />
+    <Compile Include="Persistence\IStorage.extensions.cs" />
     <Compile Include="ResetLucene.cs" />
     <Compile Include="Catalog2Lucene.cs" />
     <Compile Include="Catalog2Registration.cs" />

--- a/src/Ng/NugetServiceEndpoints.cs
+++ b/src/Ng/NugetServiceEndpoints.cs
@@ -51,7 +51,7 @@ namespace Ng
         public Uri ComposeRegistrationUrl(string packageId, string packageVersion)
         {
             // The registration URL looks similar to https://api.nuget.org/v3/registration1/autofac.mvc2/2.3.2.632.json
-            string relativePath = String.Format("{0}/{1}.json", packageId, packageVersion);
+            string relativePath = $"{packageId}/{packageVersion}.json";
 
             // The URL path must be lower cased.
             relativePath = relativePath.ToLowerInvariant();

--- a/src/Ng/Persistence/IStorage.extensions.cs
+++ b/src/Ng/Persistence/IStorage.extensions.cs
@@ -17,8 +17,6 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
     /// </summary>
     static class IStorageExtensions
     {
-        const string PACKAGESRELATIVEPATHFORMAT = "packages/{0}/{1}/{2}";
-
         /// <summary>
         /// Composes the storage resource URL for a package. 
         /// </summary>
@@ -50,7 +48,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             packageVersion = packageVersion.RemoveInvalidPathChars();
             filename = filename.RemoveInvalidPathChars();
 
-            string relativePath = String.Format(PACKAGESRELATIVEPATHFORMAT, packageId, packageVersion, filename);
+            string relativePath = $"packages/{packageId}/{packageVersion}/{filename}";
             relativePath = relativePath.ToLowerInvariant();
 
             Uri resourceUri = new Uri(storage.BaseAddress, relativePath);

--- a/src/Ng/Persistence/IStorage.extensions.cs
+++ b/src/Ng/Persistence/IStorage.extensions.cs
@@ -26,9 +26,29 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         /// <param name="packageVersion">The version of the package</param>
         /// <param name="filename">The file name to use in the resource URI.</param>
         /// <returns>The anticipated storage URL for the package.</returns>
-        public static Uri GetPackageResourceUrl(this IStorage storage, string packageId, string packageVersion, string filename)
+        public static Uri ComposePackageResourceUrl(this IStorage storage, string packageId, string packageVersion, string filename)
         {
             // The resource URI should look similar to this file:///C:/NuGet//Packages/Autofac.Mvc2/2.3.2.632/autofac.mvc2.2.3.2.632.nupkg
+
+            if (string.IsNullOrWhiteSpace(packageId))
+            {
+                throw new ArgumentNullException(packageId);
+            }
+
+            if (string.IsNullOrWhiteSpace(packageVersion))
+            {
+                throw new ArgumentNullException(packageVersion);
+            }
+
+            if (string.IsNullOrWhiteSpace(filename))
+            {
+                throw new ArgumentNullException(filename);
+            }
+
+            // Clean the strings so they don't contain any invalid path chars.
+            packageId = packageId.RemoveInvalidPathChars();
+            packageVersion = packageVersion.RemoveInvalidPathChars();
+            filename = filename.RemoveInvalidPathChars();
 
             string relativePath = String.Format(PACKAGESRELATIVEPATHFORMAT, packageId, packageVersion, filename);
             relativePath = relativePath.ToLowerInvariant();
@@ -54,6 +74,22 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Replaces the invalid file or path characters with a hyphen '-'.
+        /// </summary>
+        public static string RemoveInvalidPathChars(this string inputText)
+        {
+            if (String.IsNullOrWhiteSpace(inputText))
+            {
+                return inputText;
+            }
+
+            char[] invalidChars = Path.GetInvalidFileNameChars();
+            IEnumerable<char> newChars = inputText.Select(c => invalidChars.Contains(c) ? '-' : c);
+
+            return new String(newChars.ToArray());
         }
     }
 }

--- a/src/Ng/Persistence/IStorage.extensions.cs
+++ b/src/Ng/Persistence/IStorage.extensions.cs
@@ -44,9 +44,9 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             }
 
             // Clean the strings so they don't contain any invalid path chars.
-            packageId = packageId.RemoveInvalidPathChars();
-            packageVersion = packageVersion.RemoveInvalidPathChars();
-            filename = filename.RemoveInvalidPathChars();
+            packageId = ReplaceInvalidPathChars(packageId);
+            packageVersion = ReplaceInvalidPathChars(packageVersion);
+            filename = ReplaceInvalidPathChars(filename);
 
             string relativePath = $"packages/{packageId}/{packageVersion}/{filename}";
             relativePath = relativePath.ToLowerInvariant();
@@ -77,7 +77,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         /// <summary>
         /// Replaces the invalid file or path characters with a hyphen '-'.
         /// </summary>
-        public static string RemoveInvalidPathChars(this string inputText)
+        private static string ReplaceInvalidPathChars(string inputText)
         {
             if (String.IsNullOrWhiteSpace(inputText))
             {

--- a/src/Ng/Persistence/IStorage.extensions.cs
+++ b/src/Ng/Persistence/IStorage.extensions.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Catalog = NuGet.Services.Metadata.Catalog;
+using NuGet.Services.Metadata.Catalog.Persistence;
+
+namespace NuGet.Services.Metadata.Catalog.Persistence
+{
+    /// <summary>
+    /// Extension methods for the IStorage types
+    /// </summary>
+    static class IStorageExtensions
+    {
+        const string PACKAGESRELATIVEPATHFORMAT = "packages/{0}/{1}/{2}";
+
+        /// <summary>
+        /// Composes the storage resource URL for a package. 
+        /// </summary>
+        /// <param name="packageId">The id of the package.</param>
+        /// <param name="packageVersion">The version of the package</param>
+        /// <param name="filename">The file name to use in the resource URI.</param>
+        /// <returns>The anticipated storage URL for the package.</returns>
+        public static Uri GetPackageResourceUrl(this IStorage storage, string packageId, string packageVersion, string filename)
+        {
+            // The resource URI should look similar to this file:///C:/NuGet//Packages/Autofac.Mvc2/2.3.2.632/autofac.mvc2.2.3.2.632.nupkg
+
+            string relativePath = String.Format(PACKAGESRELATIVEPATHFORMAT, packageId, packageVersion, filename);
+            relativePath = relativePath.ToLowerInvariant();
+
+            Uri resourceUri = new Uri(storage.BaseAddress, relativePath);
+            return resourceUri;
+        }
+
+        /// <summary>
+        /// Saves the contents of a URL to storage.
+        /// </summary>
+        /// <param name="sourceUrl">The URL to download the contents from.</param>
+        /// <param name="destinationResourceUrl">The resource URL to save the contents to.</param>
+        public static void SaveUrlContents(this IStorage storage, Uri sourceUrl, Uri destinationResourceUrl)
+        {
+            using (Catalog.CollectorHttpClient client = new Catalog.CollectorHttpClient())
+            {
+                using (Stream downloadStream = client.GetStreamAsync(sourceUrl).Result)
+                {
+                    using (StreamStorageContent packageStorageContent = new StreamStorageContent(downloadStream))
+                    {
+                        storage.Save(destinationResourceUrl, packageStorageContent, new CancellationToken()).Wait();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Download the NuGet packages and save them to storage.

Note: I'm not sure we need to store the package files. Let me know if you think this is unnecessary.

I was planning on storing the packages, the idx files and the ardb files. I thought it would make repro'ing issues easier if we had the packages in storage (so we would have the exact package file that the issue repro's on.) 
