### PR TITLE
Getting the prerelase package version when stable version is not found

### DIFF
--- a/src/Ng/App.config
+++ b/src/Ng/App.config
@@ -8,7 +8,7 @@
     <add key="MinimumPackageCountAfterFiltering" value="4000"/>
     <add key="MinimumPackageCountInArdb" value="4000"/>
     <add key="MinimumArdbTextSize" value="9000000"/>
-    <add key="RequiredPackages" value="Newtonsoft.Json;EntityFramework;Microsoft.AspNet.Mvc;Microsoft.AspNet.Razor;Microsoft.AspNet.WebApi.Client;Microsoft.AspNet.WebApi.Core;Microsoft.AspNet.WebApi.WebHost;Microsoft.AspNet.WebPages;Microsoft.Net.Http;Microsoft.Web.Infrastructure"/>
+    <add key="RequiredPackages" value="Newtonsoft.Json;EntityFramework;Microsoft.AspNet.Mvc;Microsoft.AspNet.Razor;Microsoft.AspNet.WebApi.Client;Microsoft.AspNet.WebApi.Core;Microsoft.AspNet.WebApi.WebHost;Microsoft.AspNet.WebPages;Microsoft.Net.Http;Microsoft.Web.Infrastructure;MicrosoftAssemblyReferences;microsoft.framework.dependencyinjection;entityframework.migrations;microsoft.aspnet.http.extensions"/>
     <add key="FilterPackagesToIncludeBatchSize" value="500"/>
     <add key="AssemblyPackagesDirectory" value="AssemblyPackages"/>
   </appSettings>

--- a/src/Ng/Models/RegistrationIndex.cs
+++ b/src/Ng/Models/RegistrationIndex.cs
@@ -60,7 +60,7 @@ namespace Ng.Models
         /// Gets the latest stable version of this package 
         /// </summary> 
         /// <returns>The regsitration for the latest stable version of this package.</returns> 
-        /// <remarks>We determine the latest stable version from the package registration. The pacakge 
+        /// <remarks>We determine the latest stable version from the package registration. The package 
         /// registration contains the list of all the versions for this package. For each package, the  
         /// registartion entry specifies if the version is listed in the NuGet catalog. Also, in v3,  
         /// all the packages use semantic versioning, so we can use the the version number to determine  
@@ -121,6 +121,67 @@ namespace Ng.Models
             }
 
 
+            return null;
+        }
+
+        /// <summary> 
+        /// Gets the latest prerelease version of this package 
+        /// </summary> 
+        /// <returns>The regsitration for the latest prerelease version of this package.</returns> 
+        /// <remarks>We determine the latest prerelease version from the package registration. The package 
+        /// registration contains the list of all the versions for this package. For each package, the  
+        /// registartion entry specifies if the version is listed in the NuGet catalog. Also, in v3,  
+        /// all the packages use semantic versioning, so we can use the the version number to determine  
+        /// if a package is prerelease or stable. So we can find the latest stable version by finding the 
+        /// package with the largest version number, where Listed==true and PackageVersion is prerelease.</remarks> 
+        public RegistrationIndexPackage GetLatestPreReleaseVersion()
+        {
+            // The registration index might have several pages of versions. 
+            // Walk from the most recent page to the oldest page. 
+            for (int i = this.Items.Length - 1; i >= 0; i--)
+            {
+                RegistrationIndexPageItem page = this.Items[i];
+                if (page.Items == null)
+                {
+                    // If the registration index did not contain the page data, fetch  
+                    // the registration page that includes the real data. 
+                    page = page.LoadPage();
+                }
+
+
+                // Walk from the most recent version to the oldest version. 
+                for (int j = page.Items.Length - 1; j >= 0; j--)
+                {
+                    RegistrationIndexPackage package = page.Items[j];
+
+
+                    // If it's not listed, it can't be the latest stable version. 
+                    if (!package.CatalogEntry.Listed)
+                    {
+                        continue;
+                    }
+
+
+                    // If it's prerelease, it can't be the latest stable version. 
+                    NuGetVersion currentVersion = new NuGetVersion(package.CatalogEntry.PackageVersion);
+                    if (currentVersion.IsPrerelease)
+                    {
+                        // HACKHACK: For a few packages, the package.PackageContent property is empty, but the package.CatalogEntry.PackageContent
+                        // property contains the correct value (the json file is incorrect.)
+                        // If the package doesn't contain the download url, use the download url from the catalog
+                        if (package.PackageContent == null)
+                        {
+                            package.PackageContent = package.CatalogEntry.PackageContent;
+                        }
+
+                        // Do some basic validation
+                        if (package.PackageContent != null)
+                        {
+                            return package;
+                        }
+                    }
+                }
+            }
             return null;
         }
 


### PR DESCRIPTION
I am yet to test this change and will do before even I think of merging.
let me know if this looks like a reasonable solution.
