### PR TITLE
Pass the expanded directory to the indexer instead of a file list.

### DIFF
--- a/src/Ng/Elfie/ElfieCmd.cs
+++ b/src/Ng/Elfie/ElfieCmd.cs
@@ -54,19 +54,7 @@ namespace Ng.Elfie
         /// </returns>
         public string RunIndexer(string targetDirectory, string packageId, string packageVersion, int downloadCount = 0)
         {
-            // Elfie.Indexer.exe -p "C:\Temp\ElfiePaths.txt" -o ..\Index --dl 19000 --pn Arriba --rn 1.0.0.stable --url http://github.com/ElfieIndexer --full
-
-            // Get the list of files to index.
-            IEnumerable<string> assemblyFiles = this.GetFilesToIndex(targetDirectory);
-            if (assemblyFiles.Count() == 0)
-            {
-                Trace.TraceInformation("The target directory didn't contain any files to index. Skipping.");
-                return null;
-            }
-
-            // Create assembly list file
-            string assemblyListFile = Path.Combine(targetDirectory, "assemblyList.txt");
-            File.WriteAllLines(assemblyListFile, assemblyFiles);
+            // Elfie.Indexer.exe -p "C:\Temp\ExpandedPackageDirectory\" -o ..\Index --dl 19000 --pn Arriba --rn 1.0.0.stable --url http://github.com/ElfieIndexer --full
 
             // Create output directory
             string idxDirectory = Path.Combine(targetDirectory, "Idx");
@@ -76,7 +64,7 @@ namespace Ng.Elfie
             string logsDirectory = Path.Combine(targetDirectory, "Logs");
             Directory.CreateDirectory(logsDirectory);
 
-            string arguments = String.Format("-p \"{0}\" -o \"{1}\" --dl \"{2}\" --pn \"{3}\" --rn \"{4}\" --ln \"{5}\" ", assemblyListFile, idxDirectory, downloadCount, packageId, packageVersion, logsDirectory);
+            string arguments = String.Format("-p \"{0}\" -o \"{1}\" --dl \"{2}\" --pn \"{3}\" --rn \"{4}\" --ln \"{5}\" ", targetDirectory, idxDirectory, downloadCount, packageId, packageVersion, logsDirectory);
 
             string indexerApplicationPath = GetElfieIndexerPath(this.ToolsetVersion);
             Trace.TraceInformation($"Running {indexerApplicationPath} {arguments}");

--- a/src/Ng/ElfieFromCatalogCollector.cs
+++ b/src/Ng/ElfieFromCatalogCollector.cs
@@ -412,9 +412,9 @@ namespace Ng
         {
             Trace.TraceInformation("#StartActivity StageLocalPackageContents");
 
-            // The assemblies need to reside in a lib subdirectory. This is where the assembly
+            // The reference assemblies need to reside in a ref subdirectory. This is where the assembly
             // references are in a real package.
-            string libDirectory = Path.Combine(tempDirectory, "lib");
+            string libDirectory = Path.Combine(tempDirectory, "ref");
             Directory.CreateDirectory(libDirectory);
 
             // Copy the assemblies listed in the text file. Note that we're essentially assuming that

--- a/src/Ng/ElfieFromCatalogCollector.cs
+++ b/src/Ng/ElfieFromCatalogCollector.cs
@@ -414,12 +414,12 @@ namespace Ng
 
             // The reference assemblies need to reside in a ref subdirectory. This is where the assembly
             // references are in a real package.
-            string libDirectory = Path.Combine(tempDirectory, "ref");
-            Directory.CreateDirectory(libDirectory);
+            string refDirectory = Path.Combine(tempDirectory, "ref");
+            Directory.CreateDirectory(refDirectory);
 
             // Copy the assemblies listed in the text file. Note that we're essentially assuming that
             // the assembly paths are fully qualified.
-            Trace.TraceInformation($"Copying assemblies to temp directory. {libDirectory}");
+            Trace.TraceInformation($"Copying assemblies to temp directory. {refDirectory}");
             string[] files = File.ReadAllLines(localPackageFile);
             foreach (string file in files)
             {
@@ -428,7 +428,7 @@ namespace Ng
                     if (File.Exists(file))
                     {
                         string fileName = Path.GetFileName(file);
-                        string destinationDir = Path.Combine(libDirectory, Guid.NewGuid().ToString());
+                        string destinationDir = Path.Combine(refDirectory, Guid.NewGuid().ToString());
                         Directory.CreateDirectory(destinationDir);
                         string destinationPath = Path.Combine(destinationDir, fileName);
                         File.Copy(file, destinationPath, true);


### PR DESCRIPTION
This is for the "include the framework" change. Note that the indexer doesn't handle the directory yet, so we might not want to check this in yet.
